### PR TITLE
chore: fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@LearningnRunning @ds-wook @firstout @salmon131 @Harry2NY @mkk4726 @ranzzing @bohyunshin
+* @LearningnRunning @ds-wook @firstout @salmon131 @Harry2NY @mkk4726 @ranzzing @thrcle @bohyunshin


### PR DESCRIPTION
* `*`을 추가해야 codeowners가 적용되는 것으로 파악함