### PR TITLE
chore: add git attribute file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb -linguist-detectable


### PR DESCRIPTION
* repository 언어 계산에서 ipynb 파일을 제외하고자 .gitattribute 파일을 추가합니다. ([참고 링크](https://blog.naver.com/cjw531/223474550836?trackingCode=rss))