### PR TITLE
chore: update graphsage training result

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For detail description of each metric, please refer to [discussion](https://gith
 |--------------|------------------------|------------|------------|------------|-------------|-------------|
 | node2vec     | Unsupervised  learning | 0.04196    | 0.07299    | 0.09293    | 0.12739     | 0.17507     |
 | metapath2vec | Unsupervised  learning | 0.0022     | 0.00643    | 0.01028    | 0.02021     | 0.03936     |
-| graphsage    | Unsupervised  learning | TBD        | TBD        | TBD        | TBD         | TBD         |
+| graphsage    | Unsupervised  learning | 0.0013     | 0.00407    | 0.00679    | 0.01342     | 0.02551     |
 
 ### Ranking performance results with single step
 
@@ -158,7 +158,7 @@ For detail description of each metric, please refer to [discussion](https://gith
 | SVD             | Regression            | 0.00001   | 0.00002   | 0.00002   | 0.00003    | 0.00002 | 0.00003 | 0.00004 | 0.00007   |
 | node2vec        | Unsupervised learning | 0.00361   | 0.00445   | 0.00475   | 0.00523    | 0.00619 | 0.00738 | 0.00814 | 0.00989   |
 | metapath2vec    | Unsupervised learning | 0.00004   | 0.00006   | 0.00007   | 0.00008    | 0.00008 | 0.00012 | 0.00015 | 0.00021   |
-| graphsage       | Unsupervised learning | TBD       | TBD       | TBD       | TBD        | TBD     | TBD     | TBD     | TBD       |
+| graphsage       | Unsupervised learning | 0.00002   | 0.00004   | 0.00004   | 0.00005    | 0.00009 | 0.00012 | 0.00014 | 0.00018   |
 
 
 ### Ranking performance results with two step


### PR DESCRIPTION
graphsage 학습이 끝나서 결과를 업데이트 합니다. 결과는 아래와 같습니다.

### Candidate generation performance results

| Algorithm    | Task                   | recall@100 | recall@300 | recall@500 | recall@1000 | recall@2000 |
|--------------|------------------------|------------|------------|------------|-------------|-------------|
| node2vec     | Unsupervised  learning | 0.04196    | 0.07299    | 0.09293    | 0.12739     | 0.17507     |
| metapath2vec | Unsupervised  learning | 0.0022     | 0.00643    | 0.01028    | 0.02021     | 0.03936     |
| graphsage    | Unsupervised  learning | 0.0013     | 0.00407    | 0.00679    | 0.01342     | 0.02551     |

모델 아키텍쳐 상으로 node2vec, metapath2vec 보다 더 상위 호환이라고 생각되지만 아무래도 graphsage 맞춤 최적화를 많이 진행하지 못했기 때문에 결과가 별로 좋지 못하네요. metapath2vec과 비슷하게 recall이 낮게 나오는게 학습된 모델이 가지는 결점이라는 생각이 듭니다. 사실 metapath2vec, graphsage 모두 충분한 eda, 피쳐 발굴, 데이터에 대한 깊은 이해를 바탕으로 진행하지는 않았고 우선 아키텍쳐에 맞게 구현하고 한번 돌려보자!의 취지가 더 강했어요. 따라서 이 부분은 앞으로 개선해나가면 될 것 같습니다. (다른 분들 의견이나 co-work도 환영입니다 ㅋ)

graphsage는 노드의 feature을 반영하는 inductive model이기 때문에 노드를 잘 구분해주는 feature을 발굴하는게 최우선 최적화 포인트일 것 같아요. 제가 이번 학습에 사용한 피쳐는 아래와 같은데요.

* 식당 피쳐
  * 식당별 총 리뷰수
  * 식당별 평균 리뷰 점수
  * 식당의 diner_category_large에 애한 one-hot encoding
* 유저 피쳐
  * 유저의 평균 리뷰 점수
  * 유저가 방문한 식당의 각 diner_category_large의 count

위 피쳐에 대한 eda, 그리고 다른 피쳐 발굴이 필요해 보이네요.

https://github.com/lunch-corp/yamyam-lab/blob/98e14e0562fb325dcf708cb485ff05537cde80e5/config/embedding/graphsage.yaml#L4-L15


랭킹 관련된 metric을 살짝 살펴보면,

### Ranking performance results with single step

| Algorithm       | Task                  | mAP@3     | mAP@7     | mAP@10    | mAP@20     | NDCG@3  | NDCG@7  | NDCG@10 | NDCG@20   |
|-----------------|-----------------------|-----------|-----------|-----------|------------|---------|---------|---------|-----------|
| SVD             | Regression            | 0.00001   | 0.00002   | 0.00002   | 0.00003    | 0.00002 | 0.00003 | 0.00004 | 0.00007   |
| node2vec        | Unsupervised learning | 0.00361   | 0.00445   | 0.00475   | 0.00523    | 0.00619 | 0.00738 | 0.00814 | 0.00989   |
| metapath2vec    | Unsupervised learning | 0.00004   | 0.00006   | 0.00007   | 0.00008    | 0.00008 | 0.00012 | 0.00015 | 0.00021   |
| graphsage       | Unsupervised learning | 0.00002   | 0.00004   | 0.00004   | 0.00005    | 0.00009 | 0.00012 | 0.00014 | 0.00018   |

### Ranking performance results with two step

| Candidate model | number of candidates | Reranking model | Task | mAP@3        | mAP@7   | mAP@10     | mAP@20     | NDCG@3      | NDCG@7 | NDCG@10         | NDCG@20  |
| --------------- | -------------------- | --------------- | ---- |--------------|---------|------------|------------|-------------|--------|-----------------|----------|
| node2vec        | 100                | lightgbm ranker | Ranker  |  0.00083       | 0.0011       | 0.0011       | 0.0014       | 0.0031     | 0.0060     | 0.0077     | **0.0136**     |

graphsage가 제일 좋지 않네요 ㅋㅋ 학습이 젤 오래걸렸는데 이 결과만 보면 가성비가 너무 구린 것 같습니다 ㅋ 코드짠거 아까워서라도 최적화를 좀 진행해야겠어요. inductive 모델의 특징을 가지는 graphsage는 분명히 서비스 관점에서 이득인 측면이 있기 때문에 node2vec과 성능이 비슷하게 나오는데까지 튜닝만 한다면 graphsage을 사용하는게 더 이득이라는 생각이 들기도 합니다.

모델 훈련하고 결과로 얻은 plot도 첨부합니다.

![tr_loss](https://github.com/user-attachments/assets/ea84e5f6-ed70-43b1-ab47-ee7908ffd350)
![recall](https://github.com/user-attachments/assets/4e38a21d-14ee-4bba-a35e-74abfe6cc249)
![ndcg](https://github.com/user-attachments/assets/293c665e-d748-4702-a3d8-8c03dd6842d9)
![map](https://github.com/user-attachments/assets/5f98cadd-2db7-47ed-8802-ef5e526898f1)

train loss을 살펴보면 줄어들기는 하는데 그 scale이 상당히 작습니다. 즉, sgd을 하는데 뭔가 유의미하게 loss가 줄어드는 방향으로 학습이 진행되는 느낌은 아니에요. 

또한 recall, ndcg, map metric이 중간에 튀는 모습을 보입니다. node2vec 학습할 때는 이 metric이 꾸준하게 증가했는데, 이와는 대조적인 모습을 보이는 것 같아요. metapath2vec 학습할 때와 비슷하게 뭔가 학습이 안정적으로 되고있는 듯한 느낌이 들지는 않았습니다.

