### PR TITLE
feat: add validate_data option to dynamically validate data depending on DataConfig

### DIFF
--- a/src/yamyam_lab/data/base.py
+++ b/src/yamyam_lab/data/base.py
@@ -556,6 +556,7 @@ class BaseDatasetLoader(ABC):
             is_timeseries_by_time_point=self.is_timeseries_by_time_point,
             filter_config=filter_config,
             config_root_path=self.data_config.config_root_path,
+            validate_data=self.data_config.validate_data,
         )
 
         # Map reviewer and diner data

--- a/src/yamyam_lab/data/config.py
+++ b/src/yamyam_lab/data/config.py
@@ -35,6 +35,7 @@ class DataConfig:
     test: bool = False
     candidate_type: str = "node2vec"
     config_root_path: str = None
+    validate_data: bool = True
     data_source: DataSource = DataSource.GOOGLE_DRIVE
     # below parameters are used when data are directly passed in fastapi server
     review: pd.DataFrame = None

--- a/src/yamyam_lab/preprocess/preprocess.py
+++ b/src/yamyam_lab/preprocess/preprocess.py
@@ -47,6 +47,7 @@ def preprocess_common(
     filter_config: Dict[str, Any] = None,
     is_timeseries_by_time_point: bool = False,
     config_root_path: str = None,
+    validate_data: bool = True,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Common preprocessing identically applied to ranking and candidate generation.
@@ -59,17 +60,19 @@ def preprocess_common(
         filter_config (Dict[str. Any]): Filter config used when filtering reviews.
         is_timeseries_by_time_point (bool): Flag if split dataset to train / val / test using datetime.
         config_root_path (str): Root path for config
+        validate_data (bool): Whether validate data or not
 
     Returns (Tuple[pd.DataFrame, pd.DataFrame]):
         Preprocessed review dataset and diner dataset.
     """
     # step 0: validate data
-    data_validator = DataValidator()
-    review = data_validator.validate(review, name_of_df="review")
-    diner = data_validator.validate(diner, name_of_df="diner")
-    diner_with_raw_category = data_validator.validate(
-        diner_with_raw_category, name_of_df="category"
-    )
+    if validate_data:
+        data_validator = DataValidator()
+        review = data_validator.validate(review, name_of_df="review")
+        diner = data_validator.validate(diner, name_of_df="diner")
+        diner_with_raw_category = data_validator.validate(
+            diner_with_raw_category, name_of_df="category"
+        )
 
     # step 1: filter reviewers writing reviews greater than or equal to `min_reviews`
     if not is_timeseries_by_time_point:


### PR DESCRIPTION
* yamyam-ops에서 postgres db로부터 데이터를 불러온 후에 DataLoader에 넘겨줬을 때 schema가 맞지 않는 이슈가 있습니다.
* validator에서 schema의 정합성을 체크하는데 여기서 fail이 떠서 진행을 못하는 상황이네요.
* 일단 ops의 postgres db table의 schema랑 다르게 정의되었고, 전처리 로직도 달라서 칼럼별 타입이 상이합니다.
* 이 로직을 통합하는 것은 우선순위에서 밀린다고 생각해서 일단 임시방편으로 yamyam-lab의 data loader의 validator 옵션을 다이나믹하게 설정하도록 수정했습니다.