### PR TITLE
feat: add KNN-based null value imputation support in preprocessor

### DIFF
--- a/src/yamyam_lab/preprocess/diner_transform.py
+++ b/src/yamyam_lab/preprocess/diner_transform.py
@@ -331,7 +331,7 @@ class MiddleCategoryKNNImputer:
                             name_tfidf = tfidf_name.transform(name_values)
                         else:
                             # 새로운 vectorizer 학습
-                            tfidf_name = TfidfVectorizer(max_features=10)
+                            tfidf_name = TfidfVectorizer(max_features=100)
                             name_tfidf = tfidf_name.fit_transform(name_values)
                             if large_category:
                                 if large_category not in self.tfidf_vectorizers:

--- a/src/yamyam_lab/preprocessor.py
+++ b/src/yamyam_lab/preprocessor.py
@@ -11,6 +11,7 @@ import logging
 import pandas as pd
 
 from yamyam_lab.preprocess.diner_transform import (
+    CategoryProcessor,
     MiddleCategoryKNNImputer,
     MiddleCategorySimplifier,
 )
@@ -74,14 +75,29 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
     logger = logging.getLogger(__name__)
-    simplifier = MiddleCategorySimplifier(
-        config_root_path=args.config_path, data_path=args.data_path, logger=logger
-    )
 
     # 데이터 로드
     category_df = pd.read_csv(args.input)
 
-    # 간소화 처리
+    # step 1: CategoryProcessor로 대분류 분류 로직 적용
+    logger.info("=" * 60)
+    logger.info("Step 1: Category Processing")
+    logger.info("=" * 60)
+    processor = CategoryProcessor(
+        df=category_df,
+        config_root_path=args.config_path,
+    )
+    processor.process_all()
+    category_df = processor.category_preprocessed_diners
+    logger.info("Category processing completed")
+
+    # step 2: 간소화 처리
+    logger.info("=" * 60)
+    logger.info("Step 2: Middle Category Simplification")
+    logger.info("=" * 60)
+    simplifier = MiddleCategorySimplifier(
+        config_root_path=args.config_path, data_path=args.data_path, logger=logger
+    )
     result_df = simplifier.process(category_df)
 
     # KNN imputation (옵션)


### PR DESCRIPTION
KNN imputation 방법론을 활용하여 구성해보았습니다.

# 중분류 null 값 KNN 기반 Imputation 기능 추가

## 개요
중분류(`diner_category_middle`)의 null 값을 KNN(K-Nearest Neighbors) 기반으로 imputation하는 기능을 추가했습니다. 각 대분류별로 별도의 KNN 모델을 학습하여 대분류 특성에 맞는 중분류 예측을 수행합니다.

## 주요 기능

### 1. 대분류별 별도 모델 학습
- 각 대분류(한식, 일식, 양식 등)마다 독립적인 KNN 모델 학습
- 대분류별 특성에 맞춘 예측으로 정확도 향상
- 총 14개 대분류에 대해 모델 학습 완료

### 2. Feature Engineering
- **기본 카테고리 정보**: 소분류(`diner_category_small`), 상세분류(`diner_category_detail`)
- **TF-IDF 기반 텍스트 feature**: 
  - `diner_name` → 10차원 TF-IDF 벡터
  - `diner_tag` → 10차원 TF-IDF 벡터
- 총 22개 feature 사용 (소분류, 상세분류 + TF-IDF 20개)

### 3. 평가 메트릭
각 대분류별로 다음 메트릭을 계산:
- Accuracy (정확도)
- Precision (정밀도) - Macro/Weighted Average
- Recall (재현율) - Macro/Weighted Average
- F1-Score - Macro/Weighted Average

## 대분류별 성능 결과

| 대분류 | 학습 샘플 | 테스트 샘플 | 중분류 수 | Accuracy | Precision (Macro) | Recall (Macro) | F1-Score (Macro) |
|--------|----------|------------|----------|----------|------------------|----------------|------------------|
| **도시락** | 462 | 116 | 2 | **0.9914** | 0.9808 | 0.9945 | 0.9874 |
| **패스트푸드** | 2,239 | 560 | 4 | **0.9768** | 0.7380 | 0.6916 | 0.7113 |
| **카페** | 7,059 | 1,765 | 4 | **0.9456** | 0.9861 | 0.4600 | 0.5529 |
| **분식** | 3,588 | 898 | 3 | **0.9443** | 0.5950 | 0.6284 | 0.6106 |
| **아시아음식** | 1,965 | 492 | 3 | **0.8984** | 0.8496 | 0.4840 | 0.5254 |
| **뷔페** | 949 | 238 | 3 | **0.8950** | 0.7465 | 0.5481 | 0.6071 |
| **중식** | 7,074 | 1,769 | 2 | **0.8496** | 0.6907 | 0.5865 | 0.6061 |
| **퓨전요리** | 775 | 194 | 3 | **0.8093** | 0.7225 | 0.7068 | 0.7078 |
| **간식** | 14,062 | 3,516 | 4 | **0.7085** | 0.7959 | 0.5550 | 0.6254 |
| **한식** | 61,086 | 15,272 | 10 | **0.7086** | 0.6986 | 0.4697 | 0.4999 |
| **치킨** | 6,239 | 1,560 | 6 | **0.6731** | 0.3460 | 0.2941 | 0.2927 |
| **양식** | 7,418 | 1,855 | 10 | **0.6372** | 0.4779 | 0.3535 | 0.3725 |
| **술집** | 19,876 | 4,970 | 6 | **0.5922** | 0.6434 | 0.4272 | 0.4699 |
| **일식** | 7,202 | 1,801 | 5 | **0.5319** | 0.5466 | 0.4025 | 0.4054 |

### 스킵된 대분류
다음 대분류는 중분류가 1개만 있어 학습이 스킵되었습니다:
- 식품판매
- 여가시설
- 유아
- 전문대행

## 사용 방법

# 기본 사용 (KNN imputation 포함)
python -m yamyam_lab.preprocessor --use-knn-imputation

# 이웃 수 조정
python -m yamyam_lab.preprocessor --use-knn-imputation --knn-neighbors 30

# diner.csv 정보 활용 (TF-IDF feature 포함)
python -m yamyam_lab.preprocessor --use-knn-imputation --use-diner-info## 기술적 세부사항

### 모델 아키텍처
- **알고리즘**: K-Nearest Neighbors (KNN)
- **거리 가중치**: `weights="distance"` (거리 역가중치)
- **이웃 수**: 기본값 5 (데이터 크기에 따라 자동 조정)

### Feature 처리
1. **범주형 feature**: LabelEncoder로 인코딩
   - 소분류, 상세분류
   - null 값은 -1로 처리
2. **텍스트 feature**: TF-IDF 벡터화
   - `diner_name`: 10차원 TF-IDF
   - `diner_tag`: 10차원 TF-IDF (리스트 형태 처리)
   - null 값은 0으로 처리

### 학습/평가 전략
- Train/Test Split: 80/20 (stratified sampling)
- 대분류별 독립적인 모델 학습
- 대분류별 성능 평가 및 리포트

## 성능 분석

### 전체 요약
- **총 학습 모델 수**: 14개
- **평균 Accuracy**: 약 0.78 (가중 평균)
- **최고 성능**: 도시락 (0.9914), 패스트푸드 (0.9768)
- **개선 필요**: 일식 (0.5319), 술집 (0.5922)

### 특징
1. **중분류 수가 적은 대분류**에서 높은 성능 (도시락, 패스트푸드)
2. **중분류 수가 많은 대분류**에서 상대적으로 낮은 성능 (양식, 한식)
3. **TF-IDF feature**가 텍스트 정보를 효과적으로 활용 --> llm 활용하면 좋을거 같긴합니다만 왜 llm이 안되는지 모르겠네요