### PR TITLE
feat: add process_category.py script for diner category preprocessing

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,8 @@
 | `scripts/create_google_drive_token.py` | Used when creating token.json in ci                                |
 | `scripts/download_result.py`           | Used when downloading candidate generation or trained model result |
 | `scripts/generate_candidate.py`        | Used when generating candidates from trained model                 |
-| `scripts/build_regions.py` | Used when generating region cluster |
+| `scripts/build_regions.py`             | Used when generating region cluster                                |
+| `scripts/process_category.py`          | Used when processing diner category data                           |
 ## How to download candidate generation or trained model result
 
 Here, we run `scripts/download_result.py` python file to download results.
@@ -251,3 +252,59 @@ nearby_restaurants = restaurants_df[restaurants_df['region_id'] == user_region]
 ```
 
 보다 상세한 배경과 구현 설명은 `src/preprocess/region/README.md`와 `src/preprocess/region/builder.py`를 참고하세요.
+
+
+## How to process diner category data
+
+`scripts/process_category.py`는 음식점 카테고리 데이터를 전처리하는 스크립트입니다. `CategoryProcessor`와 `MiddleCategorySimplifier`를 순차적으로 실행하여 카테고리 데이터를 정제합니다.
+
+### 주요 기능
+
+- 🍗 치킨 카테고리 특수 처리 (구운치킨/프라이드치킨 분류)
+- 📊 대분류/중분류 카테고리 조정 (lowering)
+- 🔄 중분류 통합 및 이름 변경
+- 📝 중분류 간소화 (브랜드명 → 음식 종류)
+
+### 사용법
+
+```bash
+# 기본 사용법
+poetry run python scripts/process_category.py \
+    --input path/to/diner_category.csv \
+    --output path/to/diner_category_processed.csv
+
+# 커스텀 config 경로 지정
+poetry run python scripts/process_category.py \
+    --input path/to/diner_category.csv \
+    --output path/to/diner_category_processed.csv \
+    --config-root-path /custom/config/path
+
+# MiddleCategorySimplifier 스킵 (CategoryProcessor만 실행)
+poetry run python scripts/process_category.py \
+    --input path/to/diner_category.csv \
+    --output path/to/diner_category_processed.csv \
+    --skip-simplifier
+```
+
+### 파라미터 설명
+
+| Parameter name      | Required | Description                                              |
+|---------------------|----------|----------------------------------------------------------|
+| `--input`           | Yes      | 입력 CSV 파일 경로                                        |
+| `--output`          | Yes      | 출력 CSV 파일 경로                                        |
+| `--config-root-path`| No       | Config 디렉터리 경로 (기본값: `config/`)                   |
+| `--data-path`       | No       | MiddleCategorySimplifier용 데이터 경로 (기본값: `src/data/`) |
+| `--skip-simplifier` | No       | MiddleCategorySimplifier 단계 스킵                        |
+
+### 처리 단계
+
+1. **CategoryProcessor** (`config/data/category_mappings.yaml` 기반)
+   - `process_chicken_categories()`: 치킨 카테고리 처리
+   - `process_lowering_categories(level="large")`: 대분류 하향 조정
+   - `process_lowering_categories(level="middle")`: 중분류 하향 조정
+   - `process_partly_lowering_categories()`: 부분적 카테고리 조정
+   - `integrate_diner_category_middle()`: 중분류 통합
+   - `rename_diner_category_middle()`: 중분류 이름 변경
+
+2. **MiddleCategorySimplifier** (`config/data/category_mappings.yaml`의 `simplify_mapping` 기반)
+   - 브랜드/체인점 중심 분류를 음식 종류 중심으로 간소화

--- a/scripts/process_category.py
+++ b/scripts/process_category.py
@@ -1,0 +1,91 @@
+"""Script to process diner category data using CategoryProcessor and MiddleCategorySimplifier."""
+
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../src"))
+
+import pandas as pd
+
+from yamyam_lab.preprocess.diner_transform import (
+    CategoryProcessor,
+    MiddleCategorySimplifier,
+)
+
+ROOT_PATH = os.path.join(os.path.dirname(__file__), "..")
+DEFAULT_CONFIG_PATH = os.path.join(ROOT_PATH, "config")
+DEFAULT_DATA_PATH = os.path.join(ROOT_PATH, "src/data")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Process diner category CSV using CategoryProcessor and MiddleCategorySimplifier"
+    )
+    parser.add_argument(
+        "--input",
+        type=str,
+        required=True,
+        help="Path to input diner_category.csv",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Path to output diner_category_processed.csv",
+    )
+    parser.add_argument(
+        "--config-root-path",
+        type=str,
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Root path for config files (default: {DEFAULT_CONFIG_PATH})",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help=f"Path to data directory for MiddleCategorySimplifier (default: {DEFAULT_DATA_PATH})",
+    )
+    parser.add_argument(
+        "--skip-simplifier",
+        action="store_true",
+        help="Skip MiddleCategorySimplifier step",
+    )
+    return parser.parse_args()
+
+
+def main(args):
+    # Load input CSV
+    print(f"Loading input file: {args.input}")
+    df = pd.read_csv(args.input)
+    print(f"Loaded {len(df)} rows")
+
+    # Step 1: Run CategoryProcessor
+    print("Running CategoryProcessor...")
+    processor = CategoryProcessor(
+        df=df,
+        config_root_path=args.config_root_path,
+    )
+    processor.process_all()
+    processed_df = processor.category_preprocessed_diners
+    print("CategoryProcessor completed")
+
+    # Step 2: Run MiddleCategorySimplifier (optional)
+    if not args.skip_simplifier:
+        print("Running MiddleCategorySimplifier...")
+        simplifier = MiddleCategorySimplifier(
+            config_root_path=args.config_root_path,
+            data_path=args.data_path,
+        )
+        processed_df = simplifier.process(processed_df)
+        print("MiddleCategorySimplifier completed")
+
+    # Save output CSV
+    print(f"Saving output file: {args.output}")
+    processed_df.to_csv(args.output, index=False)
+    print(f"Saved {len(processed_df)} rows")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
## 요약
- 음식점 카테고리 CSV를 처리하는 `scripts/process_category.py` 스크립트 추가
- `CategoryProcessor`와 `MiddleCategorySimplifier`를 순차적으로 실행하여 카테고리 데이터 전처리
- 커스텀 config 경로 및 data 경로 옵션 지원
- `--skip-simplifier` 플래그로 `CategoryProcessor`만 실행 가능
- `scripts/README.md`에 사용법 문서 추가

## 테스트 계획
- [ ] 샘플 diner_category.csv로 스크립트 실행
- [ ] 출력 CSV에 전처리된 카테고리가 올바르게 포함되어 있는지 확인
- [ ] `--skip-simplifier` 플래그 테스트

Generated with [Claude Code](https://claude.com/claude-code)